### PR TITLE
fix: hover effect stat card not working cause it's covered by a div

### DIFF
--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -24,7 +24,6 @@ const StatCard = ({
 }: StatCardProps) => {
   return (
     <Card className={cn("overflow-hidden card-hover", className)}>
-      <div className="absolute inset-0 from-primary/5 to-transparent rounded-lg"></div>
       <CardHeader className="flex flex-row items-center justify-between pb-2 relative z-10">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon && (


### PR DESCRIPTION
This PR fixes an issue where the hover effect on the stat card wasn’t working because it was being covered by an overlapping div.