### PR TITLE
refactor: Apply map with react-map-gl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-map-gl": "^8.0.4",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "recharts": "^2.12.7",
@@ -3206,6 +3207,66 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vis.gl/react-mapbox": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.0.4.tgz",
+      "integrity": "sha512-NFk0vsWcNzSs0YCsVdt2100Zli9QWR+pje8DacpLkkGEAXFaJsFtI1oKD0Hatiate4/iAIW39SQHhgfhbeEPfQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "mapbox-gl": ">=3.5.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vis.gl/react-maplibre": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.0.4.tgz",
+      "integrity": "sha512-HwZyfLjEu+y1mUFvwDAkVxinGm8fEegaWN+O8np/WZ2Sqe5Lv6OXFpV6GWz9LOEvBYMbGuGk1FQdejo+4HCJ5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=4.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vis.gl/react-maplibre/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@vis.gl/react-maplibre/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.8.1.tgz",
@@ -3330,6 +3391,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -3440,6 +3519,25 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
       }
     },
     "node_modules/callsites": {
@@ -4139,6 +4237,18 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4347,6 +4457,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/gl-matrix": {
@@ -4609,6 +4728,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4648,11 +4776,32 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -5540,6 +5689,30 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-map-gl": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.0.4.tgz",
+      "integrity": "sha512-SHdpvFIvswsZBg6BCPcwY/nbKuCo3sJM1Cj7Sd+gA3gFRFOixD+KtZ2XSuUWq2WySL2emYEXEgrLZoXsV4Ut4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vis.gl/react-mapbox": "8.0.4",
+        "@vis.gl/react-maplibre": "8.0.4"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
@@ -5890,6 +6063,21 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5933,11 +6121,83 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6296,12 +6556,42 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-map-gl": "^8.0.4",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",

--- a/src/components/map/ProjectMap.tsx
+++ b/src/components/map/ProjectMap.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useSearchParams } from 'react-router-dom';
 import { Skeleton } from "@/components/ui/skeleton";
-import maplibregl from 'maplibre-gl';
+import Map, { NavigationControl, Marker, Popup } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 interface Project {
@@ -17,135 +17,37 @@ interface Project {
     lat: number;
     lng: number;
   };
-}
+};
 
 interface ProjectMapProps {
   projects: Project[];
-}
+};
+
+// Initial view state: Lamphun
+const INITIAL_VIEW_STATE = {
+  longitude: 98.93273443954536,
+  latitude: 18.09850631134027,
+  zoom: 8
+};
 
 const ProjectMap = ({ projects }: ProjectMapProps) => {
   const [searchParams] = useSearchParams();
-  const mapContainer = useRef<HTMLDivElement>(null);
-  const map = useRef<maplibregl.Map | null>(null);
-  const markers = useRef<maplibregl.Marker[]>([]);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [loading, setLoading] = useState(true);
+  const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
+  const [popupInfo, setPopupInfo] = useState<Project | null>(null);
 
-  // สร้าง map เมื่อ component mount แล้ว
-  useLayoutEffect(() => {
-    if (!mapContainer.current) {
-      return;
-    }
-
-    try {
-      map.current = new maplibregl.Map({
-        container: mapContainer.current,
-        style: {
-          version: 8,
-          sources: {
-            'raster-tiles': {
-              type: 'raster',
-              tiles: [
-                'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
-              ],
-              tileSize: 256,
-              attribution: '© OpenStreetMap contributors'
-            }
-          },
-          layers: [{
-            id: 'simple-tiles',
-            type: 'raster',
-            source: 'raster-tiles',
-            minzoom: 0,
-            maxzoom: 22
-          }]
-        },
-        center: [98.93273443954536, 18.09850631134027], // ลำพูน
-        zoom: 8,
-        attributionControl: false
-      });
-
-      // Wait for map to load
-      map.current.on('load', () => {
-        setLoading(false);
-
-        // Add navigation controls
-        map.current?.addControl(new maplibregl.NavigationControl(), 'top-right');
-
-        // Add attribution
-        map.current?.addControl(new maplibregl.AttributionControl({
-          compact: true
-        }), 'bottom-right');
-
-        // Add markers for each project
-        projects.forEach(project => {
-          const marker = new maplibregl.Marker({
-            color: project.status === 'completed' ? '#4ade80' :
-              project.status === 'in-progress' ? '#f59e0b' : '#94a3b8'
-          })
-            .setLngLat([project.coordinates.lng, project.coordinates.lat])
-            .setPopup(
-              new maplibregl.Popup({ offset: 25 })
-                .setHTML(`
-                  <div class="p-2">
-                    <h3 class="font-medium">${project.name}</h3>
-                    <p class="text-sm text-muted-foreground">${project.category}</p>
-                    <div class="mt-2 space-y-1">
-                      <div class="flex justify-between">
-                        <span class="text-sm">งบประมาณ:</span>
-                        <span class="font-medium">${formatCurrency(project.budget)}</span>
-                      </div>
-                      <div class="flex justify-between">
-                        <span class="text-sm">สถานะ:</span>
-                        <span class="font-medium">${getStatusText(project.status)}</span>
-                      </div>
-                    </div>
-                  </div>
-                `)
-            )
-            .addTo(map.current!);
-
-          marker.getElement().addEventListener('click', () => {
-            setSelectedProject(project);
-          });
-
-          markers.current.push(marker);
-        });
-      });
-
-      // Handle map errors
-      map.current.on('error', (e) => {
-        console.error('Map error:', e);
-        setLoading(false);
-      });
-
-    } catch (error) {
-      console.error('Error initializing map:', error);
-      setLoading(false);
-    }
-
-    // Cleanup
-    return () => {
-      markers.current.forEach(marker => marker.remove());
-      if (map.current) {
-        map.current.remove();
-      }
-    };
-  }, [projects]);
-
-  // Find the project from URL params if any
   useEffect(() => {
     const projectId = searchParams.get('project');
     if (projectId) {
       const project = projects.find(p => p.id === projectId);
       if (project) {
         setSelectedProject(project);
-        if (map.current) {
-          map.current.flyTo({
-            center: [project.coordinates.lng, project.coordinates.lat],
-            zoom: 14
-          });
-        }
+        setViewState({
+          longitude: project.coordinates.lng,
+          latitude: project.coordinates.lat,
+          zoom: 14
+        });
       }
     }
   }, [projects, searchParams]);
@@ -179,17 +81,74 @@ const ProjectMap = ({ projects }: ProjectMapProps) => {
               </CardDescription>
             </CardHeader>
             <CardContent className="p-0 h-[400px]">
-              {/* {loading ? (
-                <div className="h-full w-full flex items-center justify-center">
-                  <div className="space-y-4">
-                    <Skeleton className="h-8 w-32 mx-auto" />
-                    <Skeleton className="h-32 w-32 rounded-full mx-auto" />
-                    <Skeleton className="h-4 w-48 mx-auto" />
-                  </div>
-                </div>
-              ) : ( */}
-              <div className="h-full w-full relative" ref={mapContainer} />
-              {/* )} */}
+              <Map
+                {...viewState}
+                onMove={evt => setViewState(evt.viewState)}
+                style={{width: '100%', height: '100%'}}
+                mapStyle={{
+                  version: 8,
+                  sources: {
+                    'osm': {
+                      type: 'raster',
+                      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                      tileSize: 256,
+                      attribution: '© OpenStreetMap contributors'
+                    }
+                  },
+                  layers: [
+                    {
+                      id: 'osm-tiles',
+                      type: 'raster',
+                      source: 'osm',
+                      minzoom: 0,
+                      maxzoom: 19
+                    }
+                  ]
+                }}
+              >
+                <NavigationControl position="top-right" />
+                
+                {projects.map((project) => (
+                  <Marker
+                    key={project.id}
+                    longitude={project.coordinates.lng}
+                    latitude={project.coordinates.lat}
+                    color={
+                      project.status === 'completed' ? '#4ade80' :
+                      project.status === 'in-progress' ? '#f59e0b' : '#94a3b8'
+                    }
+                    onClick={e => {
+                      e.originalEvent.stopPropagation();
+                      setPopupInfo(project);
+                      setSelectedProject(project);
+                    }}
+                  />
+                ))}
+
+                {popupInfo && (
+                  <Popup
+                    longitude={popupInfo.coordinates.lng}
+                    latitude={popupInfo.coordinates.lat}
+                    anchor="bottom"
+                    onClose={() => setPopupInfo(null)}
+                  >
+                    <div className="p-2">
+                      <h3 className="font-medium">{popupInfo.name}</h3>
+                      <p className="text-sm text-muted-foreground">{popupInfo.category}</p>
+                      <div className="mt-2 space-y-1">
+                        <div className="flex justify-between">
+                          <span className="text-sm">งบประมาณ:</span>
+                          <span className="font-medium">{formatCurrency(popupInfo.budget)}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-sm">สถานะ:</span>
+                          <span className="font-medium">{getStatusText(popupInfo.status)}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </Popup>
+                )}
+              </Map>
             </CardContent>
           </Card>
         </div>

--- a/src/components/map/ProjectMap.tsx
+++ b/src/components/map/ProjectMap.tsx
@@ -31,18 +31,11 @@ const ProjectMap = ({ projects }: ProjectMapProps) => {
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [loading, setLoading] = useState(true);
 
-  console.log('ProjectMap component rendered');
-  console.log('Projects:', projects);
-  console.log('Map container:', mapContainer.current);
-
   // สร้าง map เมื่อ component mount แล้ว
   useLayoutEffect(() => {
     if (!mapContainer.current) {
-      console.log('No map container found');
       return;
     }
-
-    console.log('Initializing map with container:', mapContainer.current);
 
     try {
       map.current = new maplibregl.Map({
@@ -74,7 +67,6 @@ const ProjectMap = ({ projects }: ProjectMapProps) => {
 
       // Wait for map to load
       map.current.on('load', () => {
-        console.log('Map loaded successfully');
         setLoading(false);
 
         // Add navigation controls
@@ -134,7 +126,6 @@ const ProjectMap = ({ projects }: ProjectMapProps) => {
 
     // Cleanup
     return () => {
-      console.log('Cleaning up map');
       markers.current.forEach(marker => marker.remove());
       if (map.current) {
         map.current.remove();


### PR DESCRIPTION
### Description

- Apply map from `maplibre` to `react-map-gl/maplibre`(https://github.com/visgl/react-map-gl), this enabling components usage inside `Map` without applying everything in `useEffect`
- Test result based on current components:
![Screenshot 2568-05-25 at 11 23 38](https://github.com/user-attachments/assets/811875d9-335d-41f4-ba9f-8685f5940eae)
![Screenshot 2568-05-25 at 11 23 50](https://github.com/user-attachments/assets/6becea04-a824-4770-a10c-9de54e03c553)
